### PR TITLE
[Hacktoberfest] Add support to Cocoapods #2

### DIFF
--- a/view-code-helper.podspec
+++ b/view-code-helper.podspec
@@ -1,0 +1,76 @@
+#
+#  Be sure to run `pod spec lint view-code-helper.podspec' to ensure this is a
+#  valid spec and to remove all comments including this before submitting the spec.
+#
+#  To learn more about Podspec attributes see https://guides.cocoapods.org/syntax/podspec.html
+#  To see working Podspecs in the CocoaPods repo see https://github.com/CocoaPods/Specs/
+#
+
+Pod::Spec.new do |spec|
+
+  # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  These will help people to find your library, and whilst it
+  #  can feel like a chore to fill in it's definitely to your advantage. The
+  #  summary should be tweet-length, and the description more in depth.
+  #
+
+  spec.name         = "view-code-helper"
+  spec.version      = "0.1.4"
+  spec.summary      = "A package with some simple -- but useful -- helpers for building UIKit views in code."
+
+  spec.homepage     = "https://github.com/mugbug/view-code-helper"
+
+  # ―――  Spec License  ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  Licensing your code is important. See https://choosealicense.com for more info.
+  #  CocoaPods will detect a license file if there is a named LICENSE*
+  #  Popular ones are 'MIT', 'BSD' and 'Apache License, Version 2.0'.
+  #
+
+  spec.license      = "MIT"
+
+  # ――― Author Metadata  ――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  Specify the authors of the library, with email addresses. Email addresses
+  #  of the authors are extracted from the SCM log. E.g. $ git log. CocoaPods also
+  #  accepts just a name if you'd rather not provide an email address.
+  #
+  #  Specify a social_media_url where others can refer to, for example a twitter
+  #  profile URL.
+  #
+
+  spec.author             = { "Pedro Zaroni" => "zaronipedro@outlook.com" }
+
+  # ――― Platform Specifics ――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  If this Pod runs only on iOS or OS X, then specify the platform and
+  #  the deployment target. You can optionally include the target after the platform.
+  #
+
+  spec.platform     = :ios,
+
+  #  When using multiple platforms
+  spec.ios.deployment_target = "11.0"
+
+
+  # ――― Source Location ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  Specify the location from where the source should be retrieved.
+  #  Supports git, hg, bzr, svn and HTTP.
+  #
+
+  spec.source       = { :git => "https://github.com/mugbug/view-code-helper.git", :tag => "v#{spec.version}" }
+
+
+  # ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  CocoaPods is smart about how it includes source code. For source files
+  #  giving a folder will include any swift, h, m, mm, c & cpp files.
+  #  For header files it will include any header in the folder.
+  #  Not including the public_header_files will make all headers public.
+  #
+
+  spec.source_files  = "Sources", "Sources/**/*.swift"
+
+end


### PR DESCRIPTION
The aim of this PR is to add support to CocoaPods.

Proposed changes are :
- [x] Add podspec file to configure the project for create a Pod

To publish on CocoaPods.org, you need to register in the Trunk with following this [instructions](https://guides.cocoapods.org/making/getting-setup-with-trunk.html)

Issue: [Add support to Cocoapods #2](https://github.com/mugbug/view-code-helper/issues/2)